### PR TITLE
Change method of Account ID extraction from ARN

### DIFF
--- a/appstream_scripts/sagemaker-notebook.ps1
+++ b/appstream_scripts/sagemaker-notebook.ps1
@@ -19,8 +19,7 @@ Write-Host "Welcome, $UserName."
 # Get the bucket string of where AppStream syncs the Home Folder
 
 $BucketStatic = "appstream2-36fb080bb8-"
-$ArnID = $env:AppStream_Image_Arn -replace "[^0-9]", ''
-$AccountId = $ArnID.substring(1)
+$AccountId = $env:AppStream_Image_Arn.Split(":")[4]
 $BucketName = "$($BucketStatic)$($env:AWS_Region)-$($AccountId)".Trim()
 
 # Hash the Username using Get-FileHash


### PR DESCRIPTION
*Issue #, if available:*
#2

*Description of changes:*
Changed the method of extracting the Account ID from the AppStream 2.0 image ARN in `sagemaker-notebook.ps1 `.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
